### PR TITLE
Refactoring and adding Redirection module

### DIFF
--- a/pie-custom-functions-mu.php
+++ b/pie-custom-functions-mu.php
@@ -284,9 +284,10 @@ $users = get_users( array(
     'role' => 'pie_admin'
 ) );
 
+// wp_list_pluck always returns an array
 $pie_admins = wp_list_pluck( $users, 'ID' );
 
-if ( ! empty( $pie_admins ) ) {
+if ( count( $pie_admins ) > 0 ) {
     define( 'WPMUDEV_LIMIT_TO_USER', implode( ',', $pie_admins ) );
 }
 

--- a/pie-custom-functions-mu.php
+++ b/pie-custom-functions-mu.php
@@ -39,36 +39,45 @@ if ( version_compare( PHP_VERSION, '8.0', '<' ) ) {
 
 include_once plugin_dir_path( __FILE__ ) . 'pie/redirections.php';
 
-// Add custom user role for Pie Admin
-function add_pie_admin_role()
+/**
+ * Add custom user role for Pie Admin
+ * 
+ * Creates a new 'pie_admin' role with administrator capabilities.
+ * Removes any existing role with the same name first.
+ * 
+ * @since 1.0.0
+ * @return void
+ */
+function add_pie_admin_role(): void
 {
-    remove_role('pie_admin');
-    add_role('pie_admin', 'Pie Admin', get_role('administrator')->capabilities);
+    remove_role( 'pie_admin' );
+    add_role( 'pie_admin', 'Pie Admin', get_role( 'administrator' )->capabilities );
 }
 // Hook the function into the 'init' action with a lower priority
-add_action('init', __NAMESPACE__ . '\add_pie_admin_role', 10);
+add_action( 'init', __NAMESPACE__ . '\add_pie_admin_role', 10 );
 
 
 /**
  * Add the 'Pie Admin' role to any existing user that has an email address ending in '@pie.co.de'
- * This function runs when the plugin is activated
  * 
+ * This function runs during plugin initialization and searches for all users
+ * with @pie.co.de email addresses, then assigns them the pie_admin role.
+ * 
+ * @since 1.0.0
  * @return void
  */
+function add_pie_admin_role_to_existing_users(): void
+{
+    $users = get_users( array(
+        'search' => '*@pie.co.de',
+        'search_columns' => array( 'user_email' ),
+    ) );
 
- function add_pie_admin_role_to_existing_users()
- {
- 
-     $users = get_users(array(
-         'search' => '*@pie.co.de',
-         'search_columns' => array('user_email'),
-     ));
- 
-     foreach ($users as $user) {
-         assign_pie_admin_to_user($user);
-     }
- }
- add_action('init', __NAMESPACE__ . '\add_pie_admin_role_to_existing_users', 10);
+    foreach ( $users as $user ) {
+        assign_pie_admin_to_user( $user );
+    }
+}
+add_action( 'init', __NAMESPACE__ . '\add_pie_admin_role_to_existing_users', 10 );
 
 /**
  * Add a meta box to the user profile page to allow the user to select a custom role
@@ -76,253 +85,323 @@ add_action('init', __NAMESPACE__ . '\add_pie_admin_role', 10);
  * 
  * @return void
  */
-if (is_multisite()) {
+if ( is_multisite() ) {
 
     /**
      * Add a custom meta box to the user profile page
      * 
+     * Registers action hooks to display the custom role selection
+     * meta box on both user profile editing pages.
+     * 
+     * @since 1.0.0
      * @return void
      */
-    add_action('admin_init', __NAMESPACE__ . '\custom_user_profile_meta_box');
+    add_action( 'admin_init', __NAMESPACE__ . '\custom_user_profile_meta_box' );
 
-    function custom_user_profile_meta_box()
+    function custom_user_profile_meta_box(): void
     {
-        add_action('show_user_profile', __NAMESPACE__ . '\custom_user_role_meta_box_callback');
-        add_action('edit_user_profile', __NAMESPACE__ . '\custom_user_role_meta_box_callback');
+        add_action( 'show_user_profile', __NAMESPACE__ . '\custom_user_role_meta_box_callback' );
+        add_action( 'edit_user_profile', __NAMESPACE__ . '\custom_user_role_meta_box_callback' );
     }
 
     /**
      * Display the custom meta box on the user profile page
+     * 
+     * Renders a dropdown selection for assigning custom user roles.
+     * Currently supports the 'pie_admin' role selection.
      *
-     * @param [type] $user
+     * @since 1.0.0
+     * @param \WP_User $user The user object being edited
      * @return void
      */
-    function custom_user_role_meta_box_callback($user)
+    function custom_user_role_meta_box_callback( \WP_User $user ): void
     {
-        $selected_role = get_user_meta($user->ID, 'custom_user_role', true);
+        $selected_role = get_user_meta( $user->ID, 'custom_user_role', true );
 
         echo '<h3>Custom User Role</h3>';
         echo '<table class="form-table"><tr>';
         echo '<th><label for="custom_user_role">Select Custom User Role:</label></th>';
         echo '<td><select name="custom_user_role" id="custom_user_role">';
 
-        $selected = selected($selected_role, 'pie_admin', false);
+        $selected = selected( $selected_role, 'pie_admin', false );
         echo "<option value='' $selected>Select Role</option>";
         echo "<option value='pie_admin' $selected>Pie Admin</option>";
 
         echo '</select></td></tr></table>';
     }
 
-    // Save the selected custom role when the user profile is updated
-    add_action('personal_options_update', __NAMESPACE__ . '\custom_save_user_role');
-    add_action('edit_user_profile_update', __NAMESPACE__ . '\custom_save_user_role');
+    /**
+     * Save the selected custom role when the user profile is updated
+     * 
+     * Validates user permissions and sanitizes the role selection before
+     * saving it to user meta data.
+     * 
+     * @since 1.0.0
+     * @param int $user_id The ID of the user being updated
+     * @return void
+     */
+    add_action( 'personal_options_update', __NAMESPACE__ . '\custom_save_user_role' );
+    add_action( 'edit_user_profile_update', __NAMESPACE__ . '\custom_save_user_role' );
 
-    function custom_save_user_role($user_id)
+    function custom_save_user_role( int $user_id ): void
     {
-        if (current_user_can('edit_user', $user_id)) {
-            $selected_role = sanitize_key($_POST['custom_user_role']);
-            update_user_meta($user_id, 'custom_user_role', $selected_role);
+        if ( current_user_can( 'edit_user', $user_id ) && isset( $_POST['custom_user_role'] ) ) {
+            $selected_role = sanitize_key( $_POST['custom_user_role'] );
+            update_user_meta( $user_id, 'custom_user_role', $selected_role );
         }
     }
 
-    // Set the custom role after the user has been saved
-    add_action('profile_update', __NAMESPACE__ . '\custom_set_user_role',);
+    /**
+     * Set the custom role after the user has been saved
+     * 
+     * Retrieves the selected custom role from user meta and assigns
+     * it to the user if a valid role was selected.
+     * 
+     * @since 1.0.0
+     * @param int $user_id The ID of the user being updated
+     * @return void
+     */
+    add_action( 'profile_update', __NAMESPACE__ . '\custom_set_user_role' );
 
-    function custom_set_user_role($user_id)
+    function custom_set_user_role( int $user_id ): void
     {
-        $selected_role = get_user_meta($user_id, 'custom_user_role', true);
+        $selected_role = get_user_meta( $user_id, 'custom_user_role', true );
 
-
-        if ($selected_role) {
-            $user = get_userdata($user_id);
-            $user->add_role($selected_role);
+        if ( $selected_role ) {
+            $user = get_userdata( $user_id );
+            if ( $user ) {
+                $user->add_role( $selected_role );
+            }
         }
-
-        $user = get_userdata($user_id);
     }
 }
 
 /**
  * Add the 'Pie Admin' role to any user that registers with an email address ending in '@pie.co.de'
  * 
- * @param int $user_id
+ * This function is automatically triggered when a new user registers.
+ * It checks their email domain and assigns the pie_admin role if appropriate.
+ * 
+ * @since 1.0.0
+ * @param int $user_id The ID of the newly registered user
  * @return void
  */
+add_action( 'user_register', __NAMESPACE__ . '\add_pie_admin_role_to_user_pie_email' );
 
-add_action('user_register', __NAMESPACE__ . '\add_pie_admin_role_to_user_pie_email');
-
-function add_pie_admin_role_to_user_pie_email($user_id)
+function add_pie_admin_role_to_user_pie_email( int $user_id ): void
 {
-    $user = get_userdata($user_id);
-    assign_pie_admin_to_user($user);
+    $user = get_userdata( $user_id );
+    if ( $user ) {
+        assign_pie_admin_to_user( $user );
+    }
 }
 
 
 
 /**
- * Get the current users email address
+ * Assign pie_admin role to user if they have a @pie.co.de email address
  * 
- * @param object $user
- * @return string $email
+ * Checks the user's email domain and adds the 'pie_admin' role
+ * if the domain matches 'pie.co.de'.
+ * 
+ * @since 1.0.0
+ * @param \WP_User $user The user object to check and potentially assign role to
+ * @return void
  */
-
-function assign_pie_admin_to_user($user)
+function assign_pie_admin_to_user( \WP_User $user ): void
 {
     $email = $user->user_email;
-    $email = explode('@', $email);
-    $email = $email[1];
-    if ($email == 'pie.co.de') {
-        $user->add_role('pie_admin');
+    $email_parts = explode( '@', $email );
+    
+    if ( 2 === count( $email_parts ) ) {
+        $domain = $email_parts[1];
+        if ( 'pie.co.de' === $domain ) {
+            $user->add_role( 'pie_admin' );
+        }
     }
 }
 
 /**
- * Remove the 'Brand Pro' and 'Pie Custom Functions' plugins from the plugins page for all users except Pie Admin
+ * Remove specific plugins from the plugins page for all users except Pie Admin
  * 
- * @param array $plugins
- * @return array $plugins
+ * Hides 'Ultimate Branding' and 'PIE Custom Functions' plugins from the plugins
+ * list for users who don't have the 'pie_admin' role.
+ * 
+ * @since 1.0.0
+ * @param array $plugins Array of all plugins
+ * @return array Modified array of plugins with certain plugins potentially removed
  */
+add_filter( 'all_plugins', __NAMESPACE__ . '\hide_plugins_on_plugins_page' );
 
-add_filter('all_plugins', __NAMESPACE__ . '\hide_plugins_on_plugins_page');
-function hide_plugins_on_plugins_page($plugins)
+function hide_plugins_on_plugins_page( array $plugins ): array
 {
     $current_user = wp_get_current_user();
 
-    if (!in_array('pie_admin', $current_user->roles)) {
-        if (isset($plugins['ultimate-branding/ultimate-branding.php'])) {
-            unset($plugins['ultimate-branding/ultimate-branding.php']);
+    if ( ! in_array( 'pie_admin', $current_user->roles, true ) ) {
+        if ( isset( $plugins['ultimate-branding/ultimate-branding.php'] ) ) {
+            unset( $plugins['ultimate-branding/ultimate-branding.php'] );
         }
-        if (isset($plugins['pie-custom-functions/pie-custom-functions.php'])) {
-            unset($plugins['pie-custom-functions/pie-custom-functions.php']);
+        if ( isset( $plugins['pie-custom-functions/pie-custom-functions.php'] ) ) {
+            unset( $plugins['pie-custom-functions/pie-custom-functions.php'] );
         }
     }
+    
     return $plugins;
 }
 
 /**
- * Remove the 'Ultimate Branding' tips post type and 'Ultimate Branding' menu item from the admin menu for all users except Pie Admin
+ * Remove Ultimate Branding menu items from admin sidebar for non-Pie Admin users
  * 
+ * Hides Ultimate Branding related menu items and tips post type from the admin
+ * sidebar for users who don't have the 'pie_admin' role.
+ * 
+ * @since 1.0.0
  * @return void
  */
-add_action('admin_menu', __NAMESPACE__ . '\hide_plugins_from_side_bar');
-add_action('network_admin_menu', __NAMESPACE__ . '\hide_plugins_from_side_bar');
-function hide_plugins_from_side_bar()
+add_action( 'admin_menu', __NAMESPACE__ . '\hide_plugins_from_side_bar' );
+add_action( 'network_admin_menu', __NAMESPACE__ . '\hide_plugins_from_side_bar' );
+
+function hide_plugins_from_side_bar(): void
 {
     $current_user = wp_get_current_user();
 
-    if (!in_array('pie_admin', $current_user->roles)) {
-        add_filter('branda_permissions_allowed_roles', '__return_empty_array');
-        remove_menu_page('edit.php?post_type=admin_panel_tip');
-        remove_menu_page('wpmudev-videos');
+    if ( ! in_array( 'pie_admin', $current_user->roles, true ) ) {
+        add_filter( 'branda_permissions_allowed_roles', '__return_empty_array' );
+        remove_menu_page( 'edit.php?post_type=admin_panel_tip' );
+        remove_menu_page( 'wpmudev-videos' );
     }
 }
 
 /**
- * Only allow access to the 'WPMU DEV' plugin item for Pie Admin
+ * Limit WPMU DEV plugin access to pie_admin users only
  * 
- * @return void
+ * Restricts WPMU DEV plugin functionality to users with the 'pie_admin' role
+ * by setting the WPMUDEV_LIMIT_TO_USER constant with pie admin user IDs.
+ * 
+ * @since 1.0.0
  */
-
-
-$users = get_users(array(
+$users = get_users( array(
     'role' => 'pie_admin'
-));
+) );
 
-$pie_admins = wp_list_pluck($users, 'ID');
+$pie_admins = wp_list_pluck( $users, 'ID' );
 
-
-if (!empty($pie_admins)) {
-    define('WPMUDEV_LIMIT_TO_USER', implode(',', $pie_admins));
+if ( ! empty( $pie_admins ) ) {
+    define( 'WPMUDEV_LIMIT_TO_USER', implode( ',', $pie_admins ) );
 }
 
 
 /**
- * Staging setup, check the url and if it contains the word staging then begin staging setup
- * Always set to staging as WPMU DEV has staging setup for all sites
+ * Staging site setup and configuration
  * 
- * @return void
+ * Performs staging site detection and applies appropriate configurations
+ * including spam filtering and domain mapping for multisite networks.
+ * 
+ * @since 1.0.0
  */
-
 
 // Before performing checks, ensure there is a live site url, if not, assume this is the live site
 set_duplicate_site_url_lock();
 
-if (is_staging_site()) {
+if ( is_staging_site() ) {
 
-    //  Marks all WPCF7 forms as not spam if on staging sie
-    add_filter('wpcf7_spam', '__return_false');
+    // Marks all WPCF7 forms as not spam if on staging site
+    add_filter( 'wpcf7_spam', '__return_false' );
 
-    //  Hooks into admin_init for code specific to the area on staging sites
-    add_action('admin_init', __NAMESPACE__ . '\staging_setup');
+    // Hooks into admin_init for code specific to the area on staging sites
+    add_action( 'admin_init', __NAMESPACE__ . '\staging_setup' );
     
 }
 
-function staging_setup(){
-   
-    if( is_multisite()) {
+/**
+ * Configure staging site specific settings
+ * 
+ * Handles multisite domain mapping updates for staging environments.
+ * Currently applies domain mapping fixes for staging.tempurl.host environments.
+ * 
+ * @since 1.0.0
+ * @return void
+ */
+function staging_setup(): void
+{
+    if ( is_multisite() ) {
         // Temporary fix to avoid issues with staging on multisite
-        if( strpos($_SERVER['HTTP_HOST'], 'staging.tempurl.host') !== false){
+        if ( false !== strpos( $_SERVER['HTTP_HOST'], 'staging.tempurl.host' ) ) {
             update_domain_mapping();
         }
     }
-
 }
 
 /**
  * Update the domain mapping for all sites on the multisite network
  * 
- * For example if the main site is https://pie.staging.tempurl.host and the staging site is https://.pie.co.de then the staging site will be updated to https://pie.co.de.pie.staging.tempurl.host
+ * Maps staging domains to production-style URLs for testing purposes.
+ * For example: pie.co.de becomes pie.co.de.pie.staging.tempurl.host
  * 
- * TO Do: Check on how get_site_url and other functions work with multisite.
- * 
- * To Do: Ensure that links in network admin are updated to the new domain
- * 
+ * @since 1.0.0
+ * @todo Check how get_site_url and other functions work with multisite
+ * @todo Ensure that links in network admin are updated to the new domain
  * @return void
  */
-
-
-function update_domain_mapping(){
+function update_domain_mapping(): void
+{
     $sites = get_sites();
-    $main_site_url = get_site_url(1);
+    $main_site_url = get_site_url( 1 );
 
-    $main_site_url = str_replace('http://', '', $main_site_url);
-    $main_site_url = str_replace('https://', '', $main_site_url);
-    foreach($sites as $site){
+    $main_site_url = str_replace( array( 'http://', 'https://' ), '', $main_site_url );
+    
+    foreach ( $sites as $site ) {
         $site_id = $site->blog_id;
         $site_url = $site->domain;
-        if('1' == $site_id || strpos($site_url, 'staging.tempurl.host') ){
+        
+        if ( '1' === $site_id || false !== strpos( $site_url, 'staging.tempurl.host' ) ) {
             continue;
         }
+        
         $site_domain = $site_url . '.' . $main_site_url;
         $site_url = 'https://' . $site_url . '.' . $main_site_url;
-        update_blog_details($site_id, array('domain' => $site_domain, 'path' => '/'));
+        
+        update_blog_details( $site_id, array(
+            'domain' => $site_domain,
+            'path' => '/'
+        ) );
 
-        update_blog_option($site_id, 'siteurl', $site_url);
-        update_blog_option($site_id, 'home', $site_url);
+        update_blog_option( $site_id, 'siteurl', $site_url );
+        update_blog_option( $site_id, 'home', $site_url );
     }
 }
 
 
 /**
+ * Set up a protected site URL lock for staging detection
  * 
- *  Compares known live site url and curent url to check if this is a staging site
+ * Creates a protected version of the site URL that won't be affected
+ * by search and replace operations during staging site creation.
  * 
+ * @since 1.0.0
+ * @return void
  */
-
- 
-function set_duplicate_site_url_lock() {
-
+function set_duplicate_site_url_lock(): void
+{
     // Add option does not overwrite options that are already set
     add_option( 'pcf_siteurl', get_duplicate_site_lock_key() );
-
 }
 
-function get_duplicate_site_lock_key() {
-
+/**
+ * Generate a protected site URL key for staging detection
+ * 
+ * Creates a URL with an embedded constant that won't be affected by
+ * search and replace operations during staging site deployment.
+ * 
+ * @since 1.0.0
+ * @return string The protected site URL with embedded constant
+ */
+function get_duplicate_site_lock_key(): string
+{
     // Grabs site url from current site
-    $site_url = get_site_url( 'current_wp_site' );
+    $site_url = get_site_url();
 
-    // Inserts constant into url to ensure no search and replace done to staging will affect it and returns the value
+    // Inserts constant into url to ensure no search and replace done to staging will affect it
     return substr_replace(
         $site_url,
         '_[pcf_site_url]_',
@@ -331,20 +410,24 @@ function get_duplicate_site_lock_key() {
     );
 }
 
-function is_staging_site() {
-
+/**
+ * Determine if current site is a staging environment
+ * 
+ * Compares the current site URL with the protected live site URL
+ * to determine if this is a staging site or the live production site.
+ * 
+ * @since 1.0.0
+ * @return bool True if this is a staging site, false if live site
+ */
+function is_staging_site(): bool
+{
     // Gets both current site url and known live site url
     $pcf_current_site_url = get_option( 'siteurl' );
-    $pcf_live_site_url    = get_option( 'pcf_siteurl' );
+    $pcf_live_site_url = get_option( 'pcf_siteurl' );
 
     // Remove constant from saved live site url to produce accurate live site url
-    $live_site_url = str_replace('_[pcf_site_url]_', '', $pcf_live_site_url);
+    $live_site_url = str_replace( '_[pcf_site_url]_', '', $pcf_live_site_url );
 
     // Compare strings of current site and known live site, returns bool
-    if ( $live_site_url === $pcf_current_site_url ) {
-        return false;
-    } else {
-        return true;
-    }
-
+    return $live_site_url !== $pcf_current_site_url;
 }

--- a/pie-custom-functions-mu.php
+++ b/pie-custom-functions-mu.php
@@ -2,7 +2,7 @@
 
 /**
  * Plugin Name: PIE Hosting Companion (MU)
- * Description: Required Functionality for PIE Hosting
+ * Description: Essential PIE hosting functionality including URL redirections system, plugin visibility management, multisite user role controls, automatic user role assignment for @pie.co.de emails, and staging domain mapping for multisite networks.
  * Author: The team at PIE
  * Author URI: https://pie.co.de
  * Version: 1.3.3
@@ -19,6 +19,8 @@ namespace Pie\CustomFunctionsMUPlugin;
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
+
+include_once plugin_dir_path( __FILE__ ) . 'pie/redirections.php';
 
 // Add custom user role for Pie Admin
 function add_pie_admin_role()

--- a/pie-custom-functions-mu.php
+++ b/pie-custom-functions-mu.php
@@ -6,6 +6,7 @@
  * Author: The team at PIE
  * Author URI: https://pie.co.de
  * Version: 1.3.3
+ * Requires PHP: 8.0
  * License: GPL2
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: pie-custom-functions
@@ -18,6 +19,22 @@ namespace Pie\CustomFunctionsMUPlugin;
 //exit if accessed directly
 if ( ! defined( 'ABSPATH' ) ) {
     exit;
+}
+
+// Require PHP 8.0 or higher
+if ( version_compare( PHP_VERSION, '8.0', '<' ) ) {
+    add_action( 'admin_notices', function() {
+        echo '<div class="notice notice-error"><p>';
+        echo sprintf(
+            /* translators: 1: Plugin name, 2: Required PHP version, 3: Current PHP version */
+            __( '%1$s requires PHP %2$s or higher. You are running PHP %3$s.', 'pie-custom-functions' ),
+            '<strong>PIE Hosting Companion (MU)</strong>',
+            '8.0',
+            PHP_VERSION
+        );
+        echo '</p></div>';
+    } );
+    return;
 }
 
 include_once plugin_dir_path( __FILE__ ) . 'pie/redirections.php';

--- a/pie-custom-functions.php
+++ b/pie-custom-functions.php
@@ -29,8 +29,12 @@ add_action( 'plugins_loaded', __NAMESPACE__ . '\update_check' );
 add_filter( 'all_plugins', __NAMESPACE__ . '\hide_pie_custom_functions_mu_plugin_from_plugins_list' );
 
 /**
- * Load Composer autoloader
+ * Load Composer autoloader and initialize update checker
+ * 
+ * Sets up the Composer autoloader and configures the plugin update checker
+ * to monitor for new versions from the PIE GitHub repository.
  *
+ * @since 1.0.0
  * @return void
  */
 function pie_custom_functions_load_composer(): void {
@@ -44,14 +48,19 @@ function pie_custom_functions_load_composer(): void {
 }
 
 /**
- * This function handles copying the MU plugin file to the correct location and updating the version number
- * in the database.
+ * Initialize and activate the PIE Custom Functions plugin
+ * 
+ * Handles copying the MU plugin file and pie directory to the correct locations
+ * during plugin activation. Updates the version number in the database and
+ * performs comprehensive error handling with cleanup on failure.
  *
+ * @since 1.0.0
+ * @throws WP_Error If file operations fail
  * @return void
  */
 function pie_custom_functions_init(): void {
 
-    if( ! function_exists( 'get_plugin_data' ) ){
+    if ( ! function_exists( 'get_plugin_data' ) ) {
         require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
     }
 
@@ -61,7 +70,7 @@ function pie_custom_functions_init(): void {
     $local_mu_plugin_directory = plugin_dir_path( __FILE__ ) . 'pie';
 
     // Set the paths for the MU plugin file and pie directory
-    if( defined( 'WPMU_PLUGIN_DIR' ) ){
+    if ( defined( 'WPMU_PLUGIN_DIR' ) ) {
         $destination_mu_plugin_file = WPMU_PLUGIN_DIR . '/pie-custom-functions-mu.php';
         $destination_mu_plugin_directory = WPMU_PLUGIN_DIR . '/pie';
     }
@@ -77,7 +86,7 @@ function pie_custom_functions_init(): void {
     }
     
     // Copy the pie directory (WordPress core function handles overwriting)
-    if( ! function_exists( 'copy_dir' ) ){
+    if ( ! function_exists( 'copy_dir' ) ) {
         require_once( ABSPATH . 'wp-admin/includes/file.php' );
     }
     
@@ -99,30 +108,39 @@ function pie_custom_functions_init(): void {
 }
 
 /**
- * After plugins have loaded check if the plugin has been updated
- * If it has been updated then run the init function
+ * Check for plugin updates and reinitialize if necessary
  * 
+ * Compares the stored version number with the current plugin version.
+ * If an update is detected, triggers the initialization process to
+ * ensure MU plugin files are updated.
+ * 
+ * @since 1.0.0
  * @return void
  */
 function update_check(): void {
     
-    if( ! function_exists( 'get_plugin_data' ) ){
+    if ( ! function_exists( 'get_plugin_data' ) ) {
         require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
     }
 
     $current_version = get_option( 'pie_custom_functions_version' );
     $new_version = get_plugin_data( __FILE__ )['Version'];
 
-    if( version_compare( $current_version, $new_version, '<' ) ){
+    if ( version_compare( $current_version, $new_version, '<' ) ) {
         pie_custom_functions_init();
     }
 }
 
 /**
- * Hide the PIE Custom Functions MU plugin from the plugins list for all users
+ * Hide the PIE Custom Functions MU plugin from the plugins list
  * 
- * @param array $plugins
- * @return array $plugins
+ * Removes the MU plugin from the plugins page to prevent user confusion
+ * and accidental activation. The MU plugin should remain hidden from
+ * all users regardless of their role.
+ * 
+ * @since 1.0.0
+ * @param array $plugins Array of all installed plugins
+ * @return array Modified plugins array with MU plugin removed
  */
 function hide_pie_custom_functions_mu_plugin_from_plugins_list( array $plugins ): array {
     // Hide the MU plugin file if it shows up in the list

--- a/pie-custom-functions.php
+++ b/pie-custom-functions.php
@@ -69,11 +69,19 @@ function pie_custom_functions_init(): void {
     $local_mu_plugin_file = plugin_dir_path( __FILE__ ) . 'pie-custom-functions-mu.php';
     $local_mu_plugin_directory = plugin_dir_path( __FILE__ ) . 'pie';
 
-    // Set the paths for the MU plugin file and pie directory
-    if ( defined( 'WPMU_PLUGIN_DIR' ) ) {
-        $destination_mu_plugin_file = WPMU_PLUGIN_DIR . '/pie-custom-functions-mu.php';
-        $destination_mu_plugin_directory = WPMU_PLUGIN_DIR . '/pie';
+    // Ensure MU plugin directory is available
+    if ( ! defined( 'WPMU_PLUGIN_DIR' ) ) {
+        error_log( '[PIE Custom Functions] WPMU_PLUGIN_DIR not defined - MU plugins not supported' );
+        wp_die( 
+            __( 'PIE Hosting Companion activation failed: MU plugins directory not available. Please contact your hosting provider.', 'pie-custom-functions' ),
+            __( 'Plugin Activation Error', 'pie-custom-functions' ),
+            array( 'back_link' => true )
+        );
     }
+
+    // Set the paths for the MU plugin file and pie directory
+    $destination_mu_plugin_file = WPMU_PLUGIN_DIR . '/pie-custom-functions-mu.php';
+    $destination_mu_plugin_directory = WPMU_PLUGIN_DIR . '/pie';
 
     // Copy the MU plugin file (overwrites existing)
     if ( ! copy( $local_mu_plugin_file, $destination_mu_plugin_file ) ) {

--- a/pie-custom-functions.php
+++ b/pie-custom-functions.php
@@ -5,6 +5,7 @@
  * Author: The team at PIE
  * Author URI: https://pie.co.de
  * Version: 1.3.3
+ * Requires PHP: 8.0
  * License: GPL2
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  * Text Domain: pie-custom-functions
@@ -32,7 +33,7 @@ add_filter( 'all_plugins', __NAMESPACE__ . '\hide_pie_custom_functions_mu_plugin
  *
  * @return void
  */
-function pie_custom_functions_load_composer(){
+function pie_custom_functions_load_composer(): void {
     require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
     $update_checker = PucFactory::buildUpdateChecker(
@@ -48,7 +49,7 @@ function pie_custom_functions_load_composer(){
  *
  * @return void
  */
-function pie_custom_functions_init(){
+function pie_custom_functions_init(): void {
 
     if( ! function_exists( 'get_plugin_data' ) ){
         require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
@@ -60,7 +61,6 @@ function pie_custom_functions_init(){
     $local_mu_plugin_directory = plugin_dir_path( __FILE__ ) . 'pie';
 
     // Set the paths for the MU plugin file and pie directory
-
     if( defined( 'WPMU_PLUGIN_DIR' ) ){
         $destination_mu_plugin_file = WPMU_PLUGIN_DIR . '/pie-custom-functions-mu.php';
         $destination_mu_plugin_directory = WPMU_PLUGIN_DIR . '/pie';
@@ -69,68 +69,11 @@ function pie_custom_functions_init(){
     // Copy the MU plugin file (overwrites existing)
     copy( $local_mu_plugin_file, $destination_mu_plugin_file );
     
-    // Copy the pie directory (remove existing first for clean update)
-    if ( is_dir( $destination_mu_plugin_directory ) ) {
-        pie_remove_directory_recursive( $destination_mu_plugin_directory );
+    // Copy the pie directory (WordPress core function handles overwriting)
+    if( ! function_exists( 'copy_dir' ) ){
+        require_once( ABSPATH . 'wp-admin/includes/file.php' );
     }
-    pie_copy_directory_recursive( $local_mu_plugin_directory, $destination_mu_plugin_directory );
-}
-
-/**
- * Recursively copy a directory and all its contents
- *
- * @param string $source The source directory to copy from
- * @param string $destination The destination directory to copy to
- * @return bool True on success, false on failure
- */
-function pie_copy_directory_recursive( $source, $destination ) {
-    if ( ! is_dir( $source ) ) {
-        return false;
-    }
-    
-    if ( ! mkdir( $destination, 0755, true ) && ! is_dir( $destination ) ) {
-        return false;
-    }
-    
-    $files = array_diff( scandir( $source ), array( '.', '..' ) );
-    
-    foreach ( $files as $file ) {
-        $source_path = $source . '/' . $file;
-        $dest_path = $destination . '/' . $file;
-        
-        if ( is_dir( $source_path ) ) {
-            pie_copy_directory_recursive( $source_path, $dest_path );
-        } else {
-            copy( $source_path, $dest_path );
-        }
-    }
-    
-    return true;
-}
-
-/**
- * Recursively remove a directory and all its contents
- *
- * @param string $dir The directory to remove
- * @return bool True on success, false on failure
- */
-function pie_remove_directory_recursive( $dir ) {
-    if ( ! is_dir( $dir ) ) {
-        return false;
-    }
-    
-    $files = array_diff( scandir( $dir ), array( '.', '..' ) );
-    
-    foreach ( $files as $file ) {
-        $path = $dir . '/' . $file;
-        if ( is_dir( $path ) ) {
-            pie_remove_directory_recursive( $path );
-        } else {
-            unlink( $path );
-        }
-    }
-    
-    return rmdir( $dir );
+    copy_dir( $local_mu_plugin_directory, $destination_mu_plugin_directory );
 }
 
 /**
@@ -139,7 +82,7 @@ function pie_remove_directory_recursive( $dir ) {
  * 
  * @return void
  */
-function update_check(){
+function update_check(): void {
     
     if( ! function_exists( 'get_plugin_data' ) ){
         require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
@@ -159,7 +102,7 @@ function update_check(){
  * @param array $plugins
  * @return array $plugins
  */
-function hide_pie_custom_functions_mu_plugin_from_plugins_list( $plugins ) {
+function hide_pie_custom_functions_mu_plugin_from_plugins_list( array $plugins ): array {
     // Hide the MU plugin file if it shows up in the list
     if ( isset( $plugins['pie-custom-functions/pie-custom-functions-mu.php'] ) ) {
         unset( $plugins['pie-custom-functions/pie-custom-functions-mu.php'] );

--- a/pie-custom-functions.php
+++ b/pie-custom-functions.php
@@ -67,13 +67,35 @@ function pie_custom_functions_init(): void {
     }
 
     // Copy the MU plugin file (overwrites existing)
-    copy( $local_mu_plugin_file, $destination_mu_plugin_file );
+    if ( ! copy( $local_mu_plugin_file, $destination_mu_plugin_file ) ) {
+        error_log( '[PIE Custom Functions] Failed to copy MU plugin file to: ' . $destination_mu_plugin_file );
+        wp_die( 
+            __( 'PIE Hosting Companion activation failed: Could not copy MU plugin file. Please check file permissions.', 'pie-custom-functions' ),
+            __( 'Plugin Activation Error', 'pie-custom-functions' ),
+            array( 'back_link' => true )
+        );
+    }
     
     // Copy the pie directory (WordPress core function handles overwriting)
     if( ! function_exists( 'copy_dir' ) ){
         require_once( ABSPATH . 'wp-admin/includes/file.php' );
     }
-    copy_dir( $local_mu_plugin_directory, $destination_mu_plugin_directory );
+    
+    $copy_result = copy_dir( $local_mu_plugin_directory, $destination_mu_plugin_directory );
+    if ( is_wp_error( $copy_result ) || ! $copy_result ) {
+        // Clean up the MU plugin file if directory copy failed
+        if ( file_exists( $destination_mu_plugin_file ) ) {
+            unlink( $destination_mu_plugin_file );
+        }
+        
+        $error_message = is_wp_error( $copy_result ) ? $copy_result->get_error_message() : 'Unknown error';
+        error_log( '[PIE Custom Functions] Failed to copy pie directory: ' . $error_message );
+        wp_die( 
+            __( 'PIE Hosting Companion activation failed: Could not copy pie directory. Please check file permissions.', 'pie-custom-functions' ) . ' ' . $error_message,
+            __( 'Plugin Activation Error', 'pie-custom-functions' ),
+            array( 'back_link' => true )
+        );
+    }
 }
 
 /**

--- a/pie-custom-functions.php
+++ b/pie-custom-functions.php
@@ -17,15 +17,15 @@ namespace PIE\CustomFunctions;
 use YahnisElsts\PluginUpdateChecker\v5\PucFactory;
 
 // Exit if accessed directly.
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
 // Hookups
-register_activation_hook(__FILE__ , __NAMESPACE__ . '\pie_custom_functions_init');
-add_action('plugins_loaded', __NAMESPACE__ . '\pie_custom_functions_load_composer');
-add_action('plugins_loaded', __NAMESPACE__ . '\update_check');
-add_filter('all_plugins', __NAMESPACE__ . '\hide_pie_custom_functions_mu_plugin_from_plugins_list');
+register_activation_hook( __FILE__ , __NAMESPACE__ . '\pie_custom_functions_init' );
+add_action( 'plugins_loaded', __NAMESPACE__ . '\pie_custom_functions_load_composer' );
+add_action( 'plugins_loaded', __NAMESPACE__ . '\update_check' );
+add_filter( 'all_plugins', __NAMESPACE__ . '\hide_pie_custom_functions_mu_plugin_from_plugins_list' );
 
 /**
  * Load Composer autoloader
@@ -33,7 +33,7 @@ add_filter('all_plugins', __NAMESPACE__ . '\hide_pie_custom_functions_mu_plugin_
  * @return void
  */
 function pie_custom_functions_load_composer(){
-    require_once plugin_dir_path(__FILE__) . 'vendor/autoload.php';
+    require_once plugin_dir_path( __FILE__ ) . 'vendor/autoload.php';
 
     $update_checker = PucFactory::buildUpdateChecker(
         'https://pie.github.io/pie-custom-functions/update.json',
@@ -50,27 +50,27 @@ function pie_custom_functions_load_composer(){
  */
 function pie_custom_functions_init(){
 
-    if(!function_exists('get_plugin_data')){
-        require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+    if( ! function_exists( 'get_plugin_data' ) ){
+        require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
     }
 
-    update_option('pie_custom_functions_version', get_plugin_data(__FILE__)['Version']);
+    update_option( 'pie_custom_functions_version', get_plugin_data( __FILE__ )['Version'] );
 
-    $local_mu_plugin_file = plugin_dir_path(__FILE__) . 'pie-custom-functions-mu.php';
-    $local_mu_plugin_directory = plugin_dir_path(__FILE__) . 'pie';
+    $local_mu_plugin_file = plugin_dir_path( __FILE__ ) . 'pie-custom-functions-mu.php';
+    $local_mu_plugin_directory = plugin_dir_path( __FILE__ ) . 'pie';
 
     // Set the paths for the MU plugin file and pie directory
 
-    if(defined('WPMU_PLUGIN_DIR')){
+    if( defined( 'WPMU_PLUGIN_DIR' ) ){
         $destination_mu_plugin_file = WPMU_PLUGIN_DIR . '/pie-custom-functions-mu.php';
         $destination_mu_plugin_directory = WPMU_PLUGIN_DIR . '/pie';
     }
 
     // Copy the MU plugin file
-    copy($local_mu_plugin_file, $destination_mu_plugin_file);
+    copy( $local_mu_plugin_file, $destination_mu_plugin_file );
     
     // Copy the pie directory
-    pie_copy_directory_recursive($local_mu_plugin_directory, $destination_mu_plugin_directory);
+    pie_copy_directory_recursive( $local_mu_plugin_directory, $destination_mu_plugin_directory );
 }
 
 /**
@@ -80,25 +80,25 @@ function pie_custom_functions_init(){
  * @param string $destination The destination directory to copy to
  * @return bool True on success, false on failure
  */
-function pie_copy_directory_recursive($source, $destination) {
-    if (!is_dir($source)) {
+function pie_copy_directory_recursive( $source, $destination ) {
+    if ( ! is_dir( $source ) ) {
         return false;
     }
     
-    if (!mkdir($destination, 0755, true) && !is_dir($destination)) {
+    if ( ! mkdir( $destination, 0755, true ) && ! is_dir( $destination ) ) {
         return false;
     }
     
-    $files = array_diff(scandir($source), array('.', '..'));
+    $files = array_diff( scandir( $source ), array( '.', '..' ) );
     
-    foreach ($files as $file) {
+    foreach ( $files as $file ) {
         $source_path = $source . '/' . $file;
         $dest_path = $destination . '/' . $file;
         
-        if (is_dir($source_path)) {
-            pie_copy_directory_recursive($source_path, $dest_path);
+        if ( is_dir( $source_path ) ) {
+            pie_copy_directory_recursive( $source_path, $dest_path );
         } else {
-            copy($source_path, $dest_path);
+            copy( $source_path, $dest_path );
         }
     }
     
@@ -113,14 +113,14 @@ function pie_copy_directory_recursive($source, $destination) {
  */
 function update_check(){
     
-    if(!function_exists('get_plugin_data')){
-        require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+    if( ! function_exists( 'get_plugin_data' ) ){
+        require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
     }
 
-    $current_version = get_option('pie_custom_functions_version');
-    $new_version = get_plugin_data(__FILE__)['Version'];
+    $current_version = get_option( 'pie_custom_functions_version' );
+    $new_version = get_plugin_data( __FILE__ )['Version'];
 
-    if(version_compare($current_version, $new_version, '<')){
+    if( version_compare( $current_version, $new_version, '<' ) ){
         pie_custom_functions_init();
     }
 }
@@ -131,10 +131,10 @@ function update_check(){
  * @param array $plugins
  * @return array $plugins
  */
-function hide_pie_custom_functions_mu_plugin_from_plugins_list($plugins) {
+function hide_pie_custom_functions_mu_plugin_from_plugins_list( $plugins ) {
     // Hide the MU plugin file if it shows up in the list
-    if (isset($plugins['pie-custom-functions/pie-custom-functions-mu.php'])) {
-        unset($plugins['pie-custom-functions/pie-custom-functions-mu.php']);
+    if ( isset( $plugins['pie-custom-functions/pie-custom-functions-mu.php'] ) ) {
+        unset( $plugins['pie-custom-functions/pie-custom-functions-mu.php'] );
     }
     return $plugins;
 }

--- a/pie-custom-functions.php
+++ b/pie-custom-functions.php
@@ -25,6 +25,7 @@ if (!defined('ABSPATH')) {
 register_activation_hook(__FILE__ , __NAMESPACE__ . '\pie_custom_functions_init');
 add_action('plugins_loaded', __NAMESPACE__ . '\pie_custom_functions_load_composer');
 add_action('plugins_loaded', __NAMESPACE__ . '\update_check');
+add_filter('all_plugins', __NAMESPACE__ . '\hide_pie_custom_functions_mu_plugin_from_plugins_list');
 
 /**
  * Load Composer autoloader
@@ -56,15 +57,52 @@ function pie_custom_functions_init(){
     update_option('pie_custom_functions_version', get_plugin_data(__FILE__)['Version']);
 
     $local_mu_plugin_file = plugin_dir_path(__FILE__) . 'pie-custom-functions-mu.php';
+    $local_mu_plugin_directory = plugin_dir_path(__FILE__) . 'pie';
 
-    // Set the path for the MU plugin file
+    // Set the paths for the MU plugin file and pie directory
 
     if(defined('WPMU_PLUGIN_DIR')){
-        $mu_plugin_destination_file = WPMU_PLUGIN_DIR . '/pie-custom-functions-mu.php';
+        $destination_mu_plugin_file = WPMU_PLUGIN_DIR . '/pie-custom-functions-mu.php';
+        $destination_mu_plugin_directory = WPMU_PLUGIN_DIR . '/pie';
     }
 
+    // Copy the MU plugin file
+    copy($local_mu_plugin_file, $destination_mu_plugin_file);
+    
+    // Copy the pie directory
+    pie_copy_directory_recursive($local_mu_plugin_directory, $destination_mu_plugin_directory);
+}
 
-    rename($local_mu_plugin_file, $mu_plugin_destination_file);
+/**
+ * Recursively copy a directory and all its contents
+ *
+ * @param string $source The source directory to copy from
+ * @param string $destination The destination directory to copy to
+ * @return bool True on success, false on failure
+ */
+function pie_copy_directory_recursive($source, $destination) {
+    if (!is_dir($source)) {
+        return false;
+    }
+    
+    if (!mkdir($destination, 0755, true) && !is_dir($destination)) {
+        return false;
+    }
+    
+    $files = array_diff(scandir($source), array('.', '..'));
+    
+    foreach ($files as $file) {
+        $source_path = $source . '/' . $file;
+        $dest_path = $destination . '/' . $file;
+        
+        if (is_dir($source_path)) {
+            pie_copy_directory_recursive($source_path, $dest_path);
+        } else {
+            copy($source_path, $dest_path);
+        }
+    }
+    
+    return true;
 }
 
 /**
@@ -87,3 +125,16 @@ function update_check(){
     }
 }
 
+/**
+ * Hide the PIE Custom Functions MU plugin from the plugins list for all users
+ * 
+ * @param array $plugins
+ * @return array $plugins
+ */
+function hide_pie_custom_functions_mu_plugin_from_plugins_list($plugins) {
+    // Hide the MU plugin file if it shows up in the list
+    if (isset($plugins['pie-custom-functions/pie-custom-functions-mu.php'])) {
+        unset($plugins['pie-custom-functions/pie-custom-functions-mu.php']);
+    }
+    return $plugins;
+}

--- a/pie-custom-functions.php
+++ b/pie-custom-functions.php
@@ -66,10 +66,13 @@ function pie_custom_functions_init(){
         $destination_mu_plugin_directory = WPMU_PLUGIN_DIR . '/pie';
     }
 
-    // Copy the MU plugin file
+    // Copy the MU plugin file (overwrites existing)
     copy( $local_mu_plugin_file, $destination_mu_plugin_file );
     
-    // Copy the pie directory
+    // Copy the pie directory (remove existing first for clean update)
+    if ( is_dir( $destination_mu_plugin_directory ) ) {
+        pie_remove_directory_recursive( $destination_mu_plugin_directory );
+    }
     pie_copy_directory_recursive( $local_mu_plugin_directory, $destination_mu_plugin_directory );
 }
 
@@ -103,6 +106,31 @@ function pie_copy_directory_recursive( $source, $destination ) {
     }
     
     return true;
+}
+
+/**
+ * Recursively remove a directory and all its contents
+ *
+ * @param string $dir The directory to remove
+ * @return bool True on success, false on failure
+ */
+function pie_remove_directory_recursive( $dir ) {
+    if ( ! is_dir( $dir ) ) {
+        return false;
+    }
+    
+    $files = array_diff( scandir( $dir ), array( '.', '..' ) );
+    
+    foreach ( $files as $file ) {
+        $path = $dir . '/' . $file;
+        if ( is_dir( $path ) ) {
+            pie_remove_directory_recursive( $path );
+        } else {
+            unlink( $path );
+        }
+    }
+    
+    return rmdir( $dir );
 }
 
 /**

--- a/pie/redirections.php
+++ b/pie/redirections.php
@@ -175,7 +175,7 @@ function path_matches_pattern( string $path, string $pattern ): bool {
     }
     
     // Validate regex pattern before use
-    if ( ! is_string( $pattern ) || empty( $pattern ) ) {
+    if ( ! is_string( $pattern ) || '' === $pattern ) {
         error_log( sprintf(
             '[PIE Redirections] Invalid pattern type or empty pattern: %s',
             var_export( $pattern, true )

--- a/pie/redirections.php
+++ b/pie/redirections.php
@@ -182,9 +182,20 @@ function should_redirect_user( $rule ) {
  * @param array $rule The redirect rule configuration
  * @param string $request_path The original request path
  */
-function perform_redirect( $rule, $request_path ) {
+function perform_redirect( array $rule, string $request_path ): void {
     $destination = isset( $rule['destination'] ) ? $rule['destination'] : '/';
     $status_code = isset( $rule['status_code'] ) ? $rule['status_code'] : 302;
+    
+    // Validate status code - only allow valid redirect codes
+    $valid_status_codes = [ 301, 302, 303, 307, 308 ];
+    if ( ! in_array( $status_code, $valid_status_codes, true ) ) {
+        error_log( sprintf(
+            '[PIE Redirections] Invalid status code %s for rule: %s. Using 302 instead.',
+            $status_code,
+            isset( $rule['description'] ) ? $rule['description'] : 'N/A'
+        ) );
+        $status_code = 302;
+    }
     
     // Convert relative paths to full URLs
     if ( str_starts_with( $destination, '/' ) ) {

--- a/pie/redirections.php
+++ b/pie/redirections.php
@@ -107,7 +107,7 @@ function handle_redirects(): void {
  */
 function get_request_path(): string {
     // Use WordPress function to get request URI safely
-    $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( $_SERVER['REQUEST_URI'] ) : '';
+    $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) ) : '';
     
     // Parse and clean the path
     $path = wp_parse_url( $request_uri, PHP_URL_PATH );
@@ -143,7 +143,32 @@ function path_matches_pattern( string $path, string $pattern ): bool {
         $path = '/' . $path;
     }
     
-    return preg_match( $pattern, $path );
+    // Validate regex pattern before use
+    if ( ! is_string( $pattern ) || empty( $pattern ) ) {
+        error_log( sprintf(
+            '[PIE Redirections] Invalid pattern type or empty pattern: %s',
+            var_export( $pattern, true )
+        ) );
+        return false;
+    }
+    
+    // Test pattern validity with a simple string first
+    $test_result = preg_match( $pattern, '/test' );
+    
+    // Check for regex compilation errors
+    if ( false === $test_result ) {
+        error_log( sprintf(
+            '[PIE Redirections] Invalid regex pattern: %s. Error: %s',
+            $pattern,
+            preg_last_error_msg()
+        ) );
+        return false;
+    }
+    
+    // Now safely perform the actual match
+    $result = preg_match( $pattern, $path );
+    
+    return (bool) $result;
 }
 
 /**

--- a/pie/redirections.php
+++ b/pie/redirections.php
@@ -86,7 +86,34 @@ function handle_redirects(): void {
     }
 
     // Process each redirect rule
-    foreach ( $redirect_rules as $rule ) {
+    foreach ( $redirect_rules as $index => $rule ) {
+        // Validate rule structure
+        if ( ! is_array( $rule ) ) {
+            error_log( sprintf(
+                '[PIE Redirections] Invalid rule at index %d: expected array, got %s',
+                $index,
+                gettype( $rule )
+            ) );
+            continue;
+        }
+        
+        // Check required keys
+        if ( ! isset( $rule['pattern'] ) ) {
+            error_log( sprintf(
+                '[PIE Redirections] Missing required "pattern" key in rule at index %d',
+                $index
+            ) );
+            continue;
+        }
+        
+        if ( ! isset( $rule['destination'] ) ) {
+            error_log( sprintf(
+                '[PIE Redirections] Missing required "destination" key in rule at index %d',
+                $index
+            ) );
+            continue;
+        }
+        
         if ( path_matches_pattern( $request_path, $rule['pattern'] ) ) {
             if ( should_redirect_user( $rule ) ) {
                 perform_redirect( $rule, $request_path );

--- a/pie/redirections.php
+++ b/pie/redirections.php
@@ -38,11 +38,42 @@ function handle_redirects() {
         return;
     }
     
+    /**
+     * Filters the array of redirect rules.
+     *
+     * Allows plugins and themes to add custom redirect rules to the PIE Redirections system.
+     * Each rule should be an associative array containing pattern, destination, condition, and status_code.
+     *
+     * @since 1.0.0
+     *
+     * @param array $rules {
+     *     Array of redirect rule configurations.
+     *
+     *     @type array $rule {
+     *         Individual redirect rule configuration.
+     *
+     *         @type string $pattern      Required. Regex pattern to match against the request path.
+     *                                   Should be a valid PHP regex with delimiters (e.g., '#^/old-path/?$#').
+     *         @type string $destination  Required. Destination path or full URL to redirect to.
+     *                                   Can be relative path (e.g., '/new-path/') or absolute URL.
+     *         @type string $condition    Optional. Condition for when to apply the redirect.
+     *                                   Accepts 'always', 'not_admin', 'not_logged_in', 'logged_in', or callable.
+     *                                   Default 'not_admin'.
+     *         @type int    $status_code  Optional. HTTP status code for the redirect.
+     *                                   Accepts 301 (permanent) or 302 (temporary). Default 302.
+     *         @type string $description  Optional. Human-readable description for debugging purposes.
+     *     }
+     * }
+     */
+    $redirect_rules = apply_filters( __NAMESPACE__ . '\filters\redirect_rules', array() );
+
+    // Get all redirect rules - return early if none configured
+    if ( empty( $redirect_rules ) ) {
+        return;
+    }
+    
     // Get the current request path
     $request_path = get_request_path();
-    
-    // Get all redirect rules
-    $redirect_rules = get_redirect_rules();
     
     // Debug logging
 
@@ -59,30 +90,6 @@ function handle_redirects() {
             }
         }
     }
-}
-
-/**
- * Get all configured redirect rules
- * 
- * @return array Array of redirect rule configurations
- */
-function get_redirect_rules() {
-
-    /**
-     * Filter to allow adding custom redirect rules
-     * 
-     * @param array $rules Array of redirect rule configurations
-     * 
-     * Rule format:
-     * [
-     *     'pattern' => '#regex#',           // Regex pattern to match against path
-     *     'destination' => '/target/',      // Destination path or URL
-     *     'condition' => 'not_admin',       // Condition: 'not_admin', 'not_logged_in', 'always', or custom callable
-     *     'status_code' => 302,             // HTTP status code (301, 302, etc.)
-     *     'description' => 'Rule desc'      // Optional description for debugging
-     * ]
-     */
-    return apply_filters( __NAMESPACE__ . '\filters\redirect_rules', array() );
 }
 
 /**
@@ -177,6 +184,27 @@ function perform_redirect( $rule, $request_path ) {
     }
     
     // Allow filtering of the redirect URL
+    /**
+     * Filters the redirect URL before performing the redirect.
+     *
+     * Allows plugins and themes to modify the destination URL before the redirect is executed.
+     * This can be used to add query parameters, change domains, or apply custom logic
+     * to the redirect destination.
+     *
+     * @since 1.0.0
+     *
+     * @param string $redirect_url  The redirect URL that will be used for wp_redirect().
+     * @param array  $rule {
+     *     The redirect rule configuration that triggered this redirect.
+     *
+     *     @type string $pattern      Regex pattern that matched the request path.
+     *     @type string $destination  Original destination from the rule configuration.
+     *     @type string $condition    Condition that was evaluated for this redirect.
+     *     @type int    $status_code  HTTP status code for the redirect.
+     *     @type string $description  Optional description for debugging purposes.
+     * }
+     * @param string $request_path  The original request path that triggered the redirect.
+     */
     $redirect_url = apply_filters( __NAMESPACE__ . '\filters\redirect_url', $redirect_url, $rule, $request_path );
     
     // Validate the redirect URL for security

--- a/pie/redirections.php
+++ b/pie/redirections.php
@@ -156,12 +156,22 @@ function should_redirect_user( $rule ) {
             return is_user_logged_in();
             
         default:
-            // Allow custom callable conditions
+            // Allow custom callable conditions with error handling
             if ( is_callable( $condition ) ) {
-                return call_user_func( $condition, $rule );
+                try {
+                    return (bool) call_user_func( $condition, $rule );
+                } catch ( \Throwable $throwable ) {
+                    error_log(
+                        sprintf(
+                            '[PIE Redirections] Condition callback error for rule: %s. Error: %s',
+                            isset( $rule['description'] ) ? (string) $rule['description'] : 'N/A',
+                            $throwable->getMessage()
+                        )
+                    );
+                }
             }
             
-            // Default to not redirecting if condition is unknown
+            // Default to not redirecting if condition is unknown or failed
             return false;
     }
 }
@@ -183,7 +193,6 @@ function perform_redirect( $rule, $request_path ) {
         $redirect_url = $destination;
     }
     
-    // Allow filtering of the redirect URL
     /**
      * Filters the redirect URL before performing the redirect.
      *

--- a/pie/redirections.php
+++ b/pie/redirections.php
@@ -1,0 +1,243 @@
+<?php
+/**
+ * PIE Redirections - High priority URL redirections with configurable regex patterns and destinations.
+ * 
+ * Usage:
+ * 
+ * 1. Add custom redirect rules via filter:
+ *    add_filter('PIE\Redirections\filters\redirect_rules', function($rules) {
+ *        $rules[] = [
+ *            'pattern' => '#^/old-path/*$#',
+ *            'destination' => '/new-path/',
+ *            'condition' => 'not_admin',  // 'always', 'not_admin', 'not_logged_in' or callable
+ *            'status_code' => 301
+ *        ];
+ *        return $rules;
+ *    });
+ * 
+ * Patterns use regex syntax. Common examples:
+ * - '#^/old-page/?$#' matches /old-page or /old-page/
+ * - '#^/category/(.+)$#' captures and can use $1 in destination
+ * - '#^/blog/(\d+)/?$#' matches blog posts with numeric IDs
+ */
+namespace PIE\Redirections;
+
+// Prevent direct access
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Handle all configured redirects
+ * 
+ * Only processes front-end requests to avoid interfering with admin, AJAX, REST API, etc.
+ */
+function handle_redirects() {
+    // Skip processing for admin area, AJAX, REST API, and CLI requests
+    if ( is_admin() || wp_doing_ajax() || wp_is_json_request() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
+        return;
+    }
+    
+    // Get the current request path
+    $request_path = get_request_path();
+    
+    // Get all redirect rules
+    $redirect_rules = get_redirect_rules();
+    
+    // Debug logging
+
+    if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+        debug_redirect_attempts( $request_path, $redirect_rules );
+    }
+
+    // Process each redirect rule
+    foreach ( $redirect_rules as $rule ) {
+        if ( path_matches_pattern( $request_path, $rule['pattern'] ) ) {
+            if ( should_redirect_user( $rule ) ) {
+                perform_redirect( $rule, $request_path );
+                break; // Stop after first match
+            }
+        }
+    }
+}
+
+/**
+ * Get all configured redirect rules
+ * 
+ * @return array Array of redirect rule configurations
+ */
+function get_redirect_rules() {
+
+    /**
+     * Filter to allow adding custom redirect rules
+     * 
+     * @param array $rules Array of redirect rule configurations
+     * 
+     * Rule format:
+     * [
+     *     'pattern' => '#regex#',           // Regex pattern to match against path
+     *     'destination' => '/target/',      // Destination path or URL
+     *     'condition' => 'not_admin',       // Condition: 'not_admin', 'not_logged_in', 'always', or custom callable
+     *     'status_code' => 302,             // HTTP status code (301, 302, etc.)
+     *     'description' => 'Rule desc'      // Optional description for debugging
+     * ]
+     */
+    return apply_filters( __NAMESPACE__ . '\filters\redirect_rules', array() );
+}
+
+/**
+ * Get the sanitized request path
+ * 
+ * @return string The sanitized request path
+ */
+function get_request_path() {
+    // Use WordPress function to get request URI safely
+    $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( $_SERVER['REQUEST_URI'] ) : '';
+    
+    // Parse and clean the path
+    $path = wp_parse_url( $request_uri, PHP_URL_PATH );
+    
+    // Remove trailing slash and ensure we have a string
+    return rtrim( $path ?: '', '/' );
+}
+
+/**
+ * Check if the current path matches the given pattern
+ * 
+ * @param string $path The request path to check
+ * @param string $pattern The regex pattern to match against
+ * @return bool True if path matches pattern
+ */
+function path_matches_pattern( $path, $pattern ) {
+    // Handle both site root and subdirectory installations
+    $site_path = wp_parse_url( home_url(), PHP_URL_PATH );
+    $site_path = rtrim( $site_path ?: '', '/' );
+    
+    // Remove site path from request path if present
+    if ( $site_path && 0 === strpos( $path, $site_path ) ) {
+        $path = substr( $path, strlen( $site_path ) );
+    }
+    
+    // Ensure path starts with / for consistent matching
+    if ( ! str_starts_with( $path, '/' ) ) {
+        $path = '/' . $path;
+    }
+    
+    return preg_match( $pattern, $path );
+}
+
+/**
+ * Determine if the current user should be redirected based on rule condition
+ * 
+ * @param array $rule The redirect rule configuration
+ * @return bool True if user should be redirected
+ */
+function should_redirect_user( $rule ) {
+    $condition = isset( $rule['condition'] ) ? $rule['condition'] : 'not_admin';
+    
+    switch ( $condition ) {
+        case 'always':
+            return true;
+            
+        case 'not_logged_in':
+            return ! is_user_logged_in();
+            
+        case 'not_admin':
+            return ! current_user_can( 'manage_options' );
+            
+        case 'logged_in':
+            return is_user_logged_in();
+            
+        default:
+            // Allow custom callable conditions
+            if ( is_callable( $condition ) ) {
+                return call_user_func( $condition, $rule );
+            }
+            
+            // Default to not redirecting if condition is unknown
+            return false;
+    }
+}
+
+/**
+ * Perform the redirect based on rule configuration
+ * 
+ * @param array $rule The redirect rule configuration
+ * @param string $request_path The original request path
+ */
+function perform_redirect( $rule, $request_path ) {
+    $destination = isset( $rule['destination'] ) ? $rule['destination'] : '/';
+    $status_code = isset( $rule['status_code'] ) ? $rule['status_code'] : 302;
+    
+    // Convert relative paths to full URLs
+    if ( str_starts_with( $destination, '/' ) ) {
+        $redirect_url = home_url( $destination );
+    } else {
+        $redirect_url = $destination;
+    }
+    
+    // Allow filtering of the redirect URL
+    $redirect_url = apply_filters( __NAMESPACE__ . '\filters\redirect_url', $redirect_url, $rule, $request_path );
+    
+    // Validate the redirect URL for security
+    $redirect_url = wp_validate_redirect( $redirect_url, home_url() );
+    
+    // Log the redirect if debugging is enabled
+
+    if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
+        log_redirect( $request_path, $redirect_url, $rule );
+    }
+    
+    // Perform redirect with specified status code
+    wp_redirect( $redirect_url, $status_code );
+    exit;
+}
+
+/**
+ * Log redirect events for debugging (only in WP_DEBUG mode)
+ * 
+ * @param string $from_path The original path
+ * @param string $to_url The redirect destination
+ * @param array $rule The rule that triggered the redirect
+ */
+function log_redirect( $from_path, $to_url, $rule ) {
+        $description = isset( $rule['description'] ) ? $rule['description'] : 'Custom rule';
+        error_log( sprintf(
+            'PIE Redirections: [%s] Redirected "%s" to "%s" for user %s',
+            $description,
+            $from_path,
+            $to_url,
+            is_user_logged_in() ? get_current_user_id() : 'guest'
+        ) );
+}
+
+/**
+ * Debug function to log all redirect attempts (only in WP_DEBUG mode)
+ * 
+ * @param string $path The path being checked
+ * @param array $rules All redirect rules
+ */
+function debug_redirect_attempts( $path, $rules ) {
+    error_log( sprintf(
+        'PIE Redirections DEBUG: Checking path "%s" against %d rules',
+        $path,
+        count( $rules )
+    ) );
+    
+    foreach ( $rules as $index => $rule ) {
+        $matches = path_matches_pattern( $path, $rule['pattern'] );
+        $should_redirect = $matches ? should_redirect_user( $rule ) : false;
+        
+        error_log( sprintf(
+            'PIE Redirections DEBUG: Rule %d [%s] - Pattern: %s, Matches: %s, Should redirect: %s',
+            $index + 1,
+            isset( $rule['description'] ) ? $rule['description'] : 'No description',
+            $rule['pattern'],
+            $matches ? 'YES' : 'NO',
+            $should_redirect ? 'YES' : 'NO'
+        ) );
+    }
+}
+
+// Initialize the redirections handler on 'parse_request' hook (runs very early, before query setup to prevent the Events Calendar from taking over)
+add_action( 'parse_request', __NAMESPACE__ . '\handle_redirects', 1 );

--- a/pie/redirections.php
+++ b/pie/redirections.php
@@ -28,9 +28,14 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 /**
- * Handle all configured redirects
+ * Handle all configured redirects for front-end requests
  * 
- * Only processes front-end requests to avoid interfering with admin, AJAX, REST API, etc.
+ * Processes redirect rules from the configured filter and applies them
+ * to the current request. Only processes front-end requests to avoid
+ * interfering with admin area, AJAX, REST API, or CLI operations.
+ * 
+ * @since 1.0.0
+ * @return void
  */
 function handle_redirects(): void {
     // Skip processing for admin area, AJAX, REST API, and CLI requests
@@ -76,7 +81,6 @@ function handle_redirects(): void {
     $request_path = get_request_path();
     
     // Debug logging
-
     if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
         debug_redirect_attempts( $request_path, $redirect_rules );
     }
@@ -93,9 +97,13 @@ function handle_redirects(): void {
 }
 
 /**
- * Get the sanitized request path
+ * Get the sanitized and normalized request path
  * 
- * @return string The sanitized request path
+ * Extracts and sanitizes the request path from the current request URI.
+ * Handles URL parsing and removes trailing slashes for consistent processing.
+ * 
+ * @since 1.0.0
+ * @return string The sanitized request path without trailing slash
  */
 function get_request_path(): string {
     // Use WordPress function to get request URI safely
@@ -109,11 +117,16 @@ function get_request_path(): string {
 }
 
 /**
- * Check if the current path matches the given pattern
+ * Check if the current path matches the given regex pattern
  * 
+ * Handles both site root and subdirectory WordPress installations
+ * by normalizing the path before pattern matching. Ensures consistent
+ * matching behavior regardless of installation type.
+ * 
+ * @since 1.0.0
  * @param string $path The request path to check
- * @param string $pattern The regex pattern to match against
- * @return bool True if path matches pattern
+ * @param string $pattern The regex pattern to match against (with delimiters)
+ * @return bool True if path matches pattern, false otherwise
  */
 function path_matches_pattern( string $path, string $pattern ): bool {
     // Handle both site root and subdirectory installations
@@ -136,8 +149,17 @@ function path_matches_pattern( string $path, string $pattern ): bool {
 /**
  * Determine if the current user should be redirected based on rule condition
  * 
- * @param array $rule The redirect rule configuration
- * @return bool True if user should be redirected
+ * Evaluates the condition specified in the redirect rule to determine
+ * if the current user should be redirected. Supports built-in conditions
+ * and custom callable conditions with comprehensive error handling.
+ * 
+ * @since 1.0.0
+ * @param array $rule {
+ *     The redirect rule configuration.
+ *     @type string|callable $condition Condition to evaluate: 'always', 'not_admin',
+ *                                     'not_logged_in', 'logged_in', or callable.
+ * }
+ * @return bool True if user should be redirected, false otherwise
  */
 function should_redirect_user( array $rule ): bool {
     $condition = isset( $rule['condition'] ) ? $rule['condition'] : 'not_admin';
@@ -179,8 +201,19 @@ function should_redirect_user( array $rule ): bool {
 /**
  * Perform the redirect based on rule configuration
  * 
- * @param array $rule The redirect rule configuration
- * @param string $request_path The original request path
+ * Executes the actual redirect with proper URL validation, status code
+ * validation, and comprehensive error handling. Supports both relative
+ * and absolute destination URLs.
+ * 
+ * @since 1.0.0
+ * @param array $rule {
+ *     The redirect rule configuration.
+ *     @type string $destination  Destination path or URL to redirect to.
+ *     @type int    $status_code  HTTP status code (301, 302, 303, 307, 308).
+ *     @type string $description  Optional description for debugging.
+ * }
+ * @param string $request_path The original request path that triggered redirect
+ * @return void This function performs redirect and exits
  */
 function perform_redirect( array $rule, string $request_path ): void {
     $destination = isset( $rule['destination'] ) ? $rule['destination'] : '/';
@@ -231,7 +264,6 @@ function perform_redirect( array $rule, string $request_path ): void {
     $redirect_url = wp_validate_redirect( $redirect_url, home_url() );
     
     // Log the redirect if debugging is enabled
-
     if ( defined( 'WP_DEBUG' ) && WP_DEBUG && defined( 'WP_DEBUG_LOG' ) && WP_DEBUG_LOG ) {
         log_redirect( $request_path, $redirect_url, $rule );
     }
@@ -242,11 +274,20 @@ function perform_redirect( array $rule, string $request_path ): void {
 }
 
 /**
- * Log redirect events for debugging (only in WP_DEBUG mode)
+ * Log redirect events for debugging purposes
  * 
- * @param string $from_path The original path
- * @param string $to_url The redirect destination
- * @param array $rule The rule that triggered the redirect
+ * Records redirect activity to the debug log. This function performs
+ * unconditional logging - DEBUG mode checks should be handled by the caller.
+ * Includes user context and rule information for troubleshooting.
+ * 
+ * @since 1.0.0
+ * @param string $from_path The original request path that was redirected
+ * @param string $to_url The redirect destination URL
+ * @param array $rule {
+ *     The rule configuration that triggered the redirect.
+ *     @type string $description Optional description for identification.
+ * }
+ * @return void
  */
 function log_redirect( string $from_path, string $to_url, array $rule ): void {
         $description = isset( $rule['description'] ) ? $rule['description'] : 'Custom rule';
@@ -260,10 +301,17 @@ function log_redirect( string $from_path, string $to_url, array $rule ): void {
 }
 
 /**
- * Debug function to log all redirect attempts (only in WP_DEBUG mode)
+ * Debug function to log all redirect rule evaluation attempts
  * 
- * @param string $path The path being checked
- * @param array $rules All redirect rules
+ * Provides detailed logging of redirect rule processing for troubleshooting.
+ * This function performs unconditional logging - DEBUG mode checks should
+ * be handled by the caller. Shows pattern matching and condition evaluation
+ * for troubleshooting redirect configurations.
+ * 
+ * @since 1.0.0
+ * @param string $path The request path being evaluated
+ * @param array $rules Array of all redirect rules to check
+ * @return void
  */
 function debug_redirect_attempts( string $path, array $rules ): void {
     error_log( sprintf(
@@ -287,5 +335,13 @@ function debug_redirect_attempts( string $path, array $rules ): void {
     }
 }
 
-// Initialize the redirections handler on 'parse_request' hook (runs very early, before query setup to prevent the Events Calendar from taking over)
+/**
+ * Initialize the redirections handler
+ * 
+ * Registers the redirect handler on the 'parse_request' hook with priority 1
+ * to run very early in the WordPress request lifecycle, before query setup
+ * and before other plugins like Events Calendar can interfere.
+ * 
+ * @since 1.0.0
+ */
 add_action( 'parse_request', __NAMESPACE__ . '\handle_redirects', 1 );

--- a/pie/redirections.php
+++ b/pie/redirections.php
@@ -31,8 +31,9 @@ if ( ! defined( 'ABSPATH' ) ) {
  * Handle all configured redirects for front-end requests
  * 
  * Processes redirect rules from the configured filter and applies them
- * to the current request. Only processes front-end requests to avoid
- * interfering with admin area, AJAX, REST API, or CLI operations.
+ * to the current request. Validates rule structure and handles errors
+ * gracefully. Only processes front-end requests to avoid interfering 
+ * with admin area, AJAX, REST API, or CLI operations.
  * 
  * @since 1.0.0
  * @return void
@@ -126,8 +127,10 @@ function handle_redirects(): void {
 /**
  * Get the sanitized and normalized request path
  * 
- * Extracts and sanitizes the request path from the current request URI.
- * Handles URL parsing and removes trailing slashes for consistent processing.
+ * Extracts and sanitizes the request path from the current request URI
+ * using URL-specific sanitization that preserves URL structure, encoded
+ * characters, and query parameters. Handles URL parsing and removes
+ * trailing slashes for consistent processing.
  * 
  * @since 1.0.0
  * @return string The sanitized request path without trailing slash
@@ -147,13 +150,14 @@ function get_request_path(): string {
  * Check if the current path matches the given regex pattern
  * 
  * Handles both site root and subdirectory WordPress installations
- * by normalizing the path before pattern matching. Ensures consistent
- * matching behavior regardless of installation type.
+ * by normalizing the path before pattern matching. Validates regex
+ * pattern structure and handles compilation errors gracefully.
+ * Ensures consistent matching behavior regardless of installation type.
  * 
  * @since 1.0.0
  * @param string $path The request path to check
  * @param string $pattern The regex pattern to match against (with delimiters)
- * @return bool True if path matches pattern, false otherwise
+ * @return bool True if path matches pattern, false for invalid patterns or no match
  */
 function path_matches_pattern( string $path, string $pattern ): bool {
     // Handle both site root and subdirectory installations

--- a/pie/redirections.php
+++ b/pie/redirections.php
@@ -23,7 +23,7 @@
 namespace PIE\Redirections;
 
 // Prevent direct access
-if (!defined('ABSPATH')) {
+if ( ! defined( 'ABSPATH' ) ) {
     exit;
 }
 
@@ -32,7 +32,7 @@ if (!defined('ABSPATH')) {
  * 
  * Only processes front-end requests to avoid interfering with admin, AJAX, REST API, etc.
  */
-function handle_redirects() {
+function handle_redirects(): void {
     // Skip processing for admin area, AJAX, REST API, and CLI requests
     if ( is_admin() || wp_doing_ajax() || wp_is_json_request() || ( defined( 'WP_CLI' ) && WP_CLI ) ) {
         return;
@@ -68,7 +68,7 @@ function handle_redirects() {
     $redirect_rules = apply_filters( __NAMESPACE__ . '\filters\redirect_rules', array() );
 
     // Get all redirect rules - return early if none configured
-    if ( empty( $redirect_rules ) ) {
+    if ( ! isset( $redirect_rules ) || ! is_array( $redirect_rules ) || 0 === count( $redirect_rules ) ) {
         return;
     }
     
@@ -97,7 +97,7 @@ function handle_redirects() {
  * 
  * @return string The sanitized request path
  */
-function get_request_path() {
+function get_request_path(): string {
     // Use WordPress function to get request URI safely
     $request_uri = isset( $_SERVER['REQUEST_URI'] ) ? sanitize_text_field( $_SERVER['REQUEST_URI'] ) : '';
     
@@ -115,7 +115,7 @@ function get_request_path() {
  * @param string $pattern The regex pattern to match against
  * @return bool True if path matches pattern
  */
-function path_matches_pattern( $path, $pattern ) {
+function path_matches_pattern( string $path, string $pattern ): bool {
     // Handle both site root and subdirectory installations
     $site_path = wp_parse_url( home_url(), PHP_URL_PATH );
     $site_path = rtrim( $site_path ?: '', '/' );
@@ -139,7 +139,7 @@ function path_matches_pattern( $path, $pattern ) {
  * @param array $rule The redirect rule configuration
  * @return bool True if user should be redirected
  */
-function should_redirect_user( $rule ) {
+function should_redirect_user( array $rule ): bool {
     $condition = isset( $rule['condition'] ) ? $rule['condition'] : 'not_admin';
     
     switch ( $condition ) {
@@ -248,7 +248,7 @@ function perform_redirect( array $rule, string $request_path ): void {
  * @param string $to_url The redirect destination
  * @param array $rule The rule that triggered the redirect
  */
-function log_redirect( $from_path, $to_url, $rule ) {
+function log_redirect( string $from_path, string $to_url, array $rule ): void {
         $description = isset( $rule['description'] ) ? $rule['description'] : 'Custom rule';
         error_log( sprintf(
             'PIE Redirections: [%s] Redirected "%s" to "%s" for user %s',
@@ -265,7 +265,7 @@ function log_redirect( $from_path, $to_url, $rule ) {
  * @param string $path The path being checked
  * @param array $rules All redirect rules
  */
-function debug_redirect_attempts( $path, $rules ) {
+function debug_redirect_attempts( string $path, array $rules ): void {
     error_log( sprintf(
         'PIE Redirections DEBUG: Checking path "%s" against %d rules',
         $path,


### PR DESCRIPTION
Resolves #52 
Structured to add a directory for other modules to help with code organisation

Added Redirection module
I had to create an MU Plugin for Shoreditch Business School that could perform redirects before The Events Calendar, and hooking in on `parse_request` seems to be the latest point it's possible. I know that we perform some redirections for other clients, so I have added this utility to our plugin. It does nothing unless something is added to the `PIE\Redirections\filters\redirect_rules` filter - the filter is documented in the code for reference

Change:
Previously this plugin would move the mu-plugin file. Now it only copies it in the case that we might need to refer. The reference to the MU Plugin File is removed from the normal Plugins list for all users to avoid confusion