### PR TITLE
Fix/plugin updates/app.asana.com/1/100438094841948/project/1206474484537567/task/1215712806607352

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Fix: atomic MU plugin deployment to prevent partial updates and site outage on failed auto-update
 
 ## [1.5.0] 2026-06-15 
 - Add shared functions file 

--- a/pie-custom-functions-mu.php
+++ b/pie-custom-functions-mu.php
@@ -5,7 +5,7 @@
  * Description: Essential PIE hosting functionality including URL redirections system, plugin visibility management, multisite user role controls, automatic user role assignment for @pie.co.de emails, and staging domain mapping for multisite networks.
  * Author: The team at PIE
  * Author URI: https://pie.co.de
- * Version: 1.5.1
+ * Version: 1.5.0
  * Requires PHP: 8.0
  * License: GPL2
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/pie-custom-functions-mu.php
+++ b/pie-custom-functions-mu.php
@@ -5,7 +5,7 @@
  * Description: Essential PIE hosting functionality including URL redirections system, plugin visibility management, multisite user role controls, automatic user role assignment for @pie.co.de emails, and staging domain mapping for multisite networks.
  * Author: The team at PIE
  * Author URI: https://pie.co.de
- * Version: 1.5.0
+ * Version: 1.5.1
  * Requires PHP: 8.0
  * License: GPL2
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/pie-custom-functions.php
+++ b/pie-custom-functions.php
@@ -55,7 +55,6 @@ function pie_custom_functions_load_composer(): void {
  * performs comprehensive error handling with cleanup on failure.
  *
  * @since 1.0.0
- * @throws WP_Error If file operations fail
  * @return void
  */
 function pie_custom_functions_init(): void {
@@ -93,26 +92,62 @@ function pie_custom_functions_init(): void {
         );
     }
     
-    // Copy the pie directory (WordPress core function handles overwriting)
-    if ( ! function_exists( 'copy_dir' ) ) {
-        require_once( ABSPATH . 'wp-admin/includes/file.php' );
-    }
-    
-    $copy_result = copy_dir( $local_mu_plugin_directory, $destination_mu_plugin_directory );
-    if ( is_wp_error( $copy_result ) || ! $copy_result ) {
-        // Clean up the MU plugin file if directory copy failed
+    // Copy the pie directory using native PHP (no WP_Filesystem dependency).
+    if ( ! copy_directory_recursive( $local_mu_plugin_directory, $destination_mu_plugin_directory ) ) {
+        // Clean up the MU plugin file if directory copy failed.
         if ( file_exists( $destination_mu_plugin_file ) ) {
             unlink( $destination_mu_plugin_file );
         }
-        
-        $error_message = is_wp_error( $copy_result ) ? $copy_result->get_error_message() : 'Unknown error';
-        error_log( '[PIE Custom Functions] Failed to copy pie directory: ' . $error_message );
-        wp_die( 
-            __( 'PIE Hosting Companion activation failed: Could not copy pie directory. Please check file permissions.', 'pie-custom-functions' ) . ' ' . $error_message,
+
+        error_log( '[PIE Custom Functions] Failed to copy pie directory to: ' . $destination_mu_plugin_directory );
+        wp_die(
+            __( 'PIE Hosting Companion activation failed: Could not copy pie directory. Please check file permissions.', 'pie-custom-functions' ),
             __( 'Plugin Activation Error', 'pie-custom-functions' ),
             array( 'back_link' => true )
         );
     }
+}
+
+/**
+ * Recursively copy a directory using native PHP filesystem functions.
+ *
+ * @since 1.5.1
+ * @param string $source      Absolute path to the source directory.
+ * @param string $destination Absolute path to the destination directory.
+ * @return bool True on success, false on any failure.
+ */
+function copy_directory_recursive( string $source, string $destination ): bool {
+    if ( ! is_dir( $source ) ) {
+        return false;
+    }
+
+    if ( ! is_dir( $destination ) && ! mkdir( $destination, 0755, true ) ) {
+        return false;
+    }
+
+    $entries = scandir( $source );
+    if ( false === $entries ) {
+        return false;
+    }
+
+    foreach ( $entries as $entry ) {
+        if ( '.' === $entry || '..' === $entry ) {
+            continue;
+        }
+
+        $source_path      = $source . DIRECTORY_SEPARATOR . $entry;
+        $destination_path = $destination . DIRECTORY_SEPARATOR . $entry;
+
+        if ( is_dir( $source_path ) ) {
+            if ( ! copy_directory_recursive( $source_path, $destination_path ) ) {
+                return false;
+            }
+        } elseif ( ! copy( $source_path, $destination_path ) ) {
+            return false;
+        }
+    }
+
+    return true;
 }
 
 /**

--- a/pie-custom-functions.php
+++ b/pie-custom-functions.php
@@ -50,9 +50,12 @@ function pie_custom_functions_load_composer(): void {
 /**
  * Initialize and activate the PIE Custom Functions plugin
  * 
- * Handles copying the MU plugin file and pie directory to the correct locations
- * during plugin activation. Updates the version number in the database and
- * performs comprehensive error handling with cleanup on failure.
+ * Copies the pie/ directory and MU loader file to the MU plugins directory,
+ * then records the current version. The directory is copied atomically via a
+ * temp-and-rename strategy so the live directory is never partially updated.
+ * The MU loader is copied only after the directory swap succeeds. If either
+ * step fails the version option is not bumped, allowing the next request to
+ * retry the full update.
  *
  * @since 1.0.0
  * @return void
@@ -79,9 +82,9 @@ function pie_custom_functions_init(): void {
     $destination_mu_plugin_file      = WPMU_PLUGIN_DIR . '/pie-custom-functions-mu.php';
     $destination_mu_plugin_directory = WPMU_PLUGIN_DIR . '/pie';
 
-    // Copy the pie/ directory first — the MU loader depends on files inside it.
-    // If this fails the MU loader file is not touched, so the site stays on the previous version.
-    if ( ! copy_directory_recursive( $local_mu_plugin_directory, $destination_mu_plugin_directory ) ) {
+    // Copy the pie/ directory atomically (temp copy then rename) so the live
+    // directory is never in a partial state. The MU loader is not touched if this fails.
+    if ( ! pie_custom_functions_copy_directory_atomic( $local_mu_plugin_directory, $destination_mu_plugin_directory ) ) {
         error_log( '[PIE Custom Functions] Failed to copy pie directory to: ' . $destination_mu_plugin_directory );
         wp_die(
             __( 'PIE Hosting Companion activation failed: Could not copy pie directory. Please check file permissions.', 'pie-custom-functions' ),
@@ -90,10 +93,13 @@ function pie_custom_functions_init(): void {
         );
     }
 
-    // Copy the MU loader file after its dependencies are in place.
+    // Write the MU loader to a temp file in the same directory, then rename atomically
+    // over the live file. Same-directory guarantees the rename is on the same filesystem.
     // If this fails the version option is not bumped, so the next request retries the full update.
-    if ( ! copy( $local_mu_plugin_file, $destination_mu_plugin_file ) ) {
-        error_log( '[PIE Custom Functions] Failed to copy MU plugin file to: ' . $destination_mu_plugin_file );
+    $temp_mu_plugin_file = $destination_mu_plugin_file . '.new';
+
+    if ( ! copy( $local_mu_plugin_file, $temp_mu_plugin_file ) ) {
+        error_log( '[PIE Custom Functions] Failed to copy MU plugin file to: ' . $temp_mu_plugin_file );
         wp_die(
             __( 'PIE Hosting Companion activation failed: Could not copy MU plugin file. Please check file permissions.', 'pie-custom-functions' ),
             __( 'Plugin Activation Error', 'pie-custom-functions' ),
@@ -101,7 +107,17 @@ function pie_custom_functions_init(): void {
         );
     }
 
-    // Both copies succeeded — safe to record the new version.
+    if ( ! rename( $temp_mu_plugin_file, $destination_mu_plugin_file ) ) {
+        unlink( $temp_mu_plugin_file );
+        error_log( '[PIE Custom Functions] Failed to promote MU plugin file to: ' . $destination_mu_plugin_file );
+        wp_die(
+            __( 'PIE Hosting Companion activation failed: Could not install MU plugin file. Please check file permissions.', 'pie-custom-functions' ),
+            __( 'Plugin Activation Error', 'pie-custom-functions' ),
+            array( 'back_link' => true )
+        );
+    }
+
+    // pie/ swap and MU loader promotion both succeeded — safe to record the new version.
     update_option( 'pie_custom_functions_version', get_plugin_data( __FILE__ )['Version'] );
 }
 
@@ -113,7 +129,7 @@ function pie_custom_functions_init(): void {
  * @param string $destination Absolute path to the destination directory.
  * @return bool True on success, false on any failure.
  */
-function copy_directory_recursive( string $source, string $destination ): bool {
+function pie_custom_functions_copy_directory_recursive( string $source, string $destination ): bool {
     if ( ! is_dir( $source ) ) {
         return false;
     }
@@ -136,7 +152,7 @@ function copy_directory_recursive( string $source, string $destination ): bool {
         $destination_path = $destination . DIRECTORY_SEPARATOR . $entry;
 
         if ( is_dir( $source_path ) ) {
-            if ( ! copy_directory_recursive( $source_path, $destination_path ) ) {
+            if ( ! pie_custom_functions_copy_directory_recursive( $source_path, $destination_path ) ) {
                 return false;
             }
         } elseif ( ! copy( $source_path, $destination_path ) ) {
@@ -145,6 +161,92 @@ function copy_directory_recursive( string $source, string $destination ): bool {
     }
 
     return true;
+}
+
+/**
+ * Copy a directory atomically by writing to a temporary location first.
+ *
+ * Copies $source to $destination-new, then renames the existing $destination
+ * to $destination-old and promotes $destination-new to $destination. The live
+ * directory is replaced in a single rename, so it is never partially updated.
+ * Cleans up temp directories on any failure and attempts to restore the
+ * previous directory if the promotion rename fails.
+ *
+ * @since 1.5.1
+ * @param string $source      Absolute path to the source directory.
+ * @param string $destination Absolute path to the destination directory.
+ * @return bool True on success, false on any failure.
+ */
+function pie_custom_functions_copy_directory_atomic( string $source, string $destination ): bool {
+    $temp = $destination . '-new';
+    $old  = $destination . '-old';
+
+    // Remove any leftover temp directory from a previous failed attempt.
+    if ( is_dir( $temp ) ) {
+        pie_custom_functions_delete_directory_recursive( $temp );
+    }
+
+    // Copy into the temporary location — live directory is untouched until success.
+    if ( ! pie_custom_functions_copy_directory_recursive( $source, $temp ) ) {
+        pie_custom_functions_delete_directory_recursive( $temp );
+        return false;
+    }
+
+    // Move the current directory aside, then promote the new one.
+    if ( is_dir( $destination ) && ! rename( $destination, $old ) ) {
+        pie_custom_functions_delete_directory_recursive( $temp );
+        return false;
+    }
+
+    if ( ! rename( $temp, $destination ) ) {
+        // Promotion failed — restore the previous directory.
+        if ( is_dir( $old ) ) {
+            rename( $old, $destination );
+        }
+        pie_custom_functions_delete_directory_recursive( $temp );
+        return false;
+    }
+
+    // New directory is live — remove the old one.
+    if ( is_dir( $old ) ) {
+        pie_custom_functions_delete_directory_recursive( $old );
+    }
+
+    return true;
+}
+
+/**
+ * Recursively delete a directory and all its contents.
+ *
+ * @since 1.5.1
+ * @param string $path Absolute path to the directory to delete.
+ * @return bool True on success, false if the path is not a directory or cannot be scanned.
+ */
+function pie_custom_functions_delete_directory_recursive( string $path ): bool {
+    if ( ! is_dir( $path ) ) {
+        return false;
+    }
+
+    $entries = scandir( $path );
+    if ( false === $entries ) {
+        return false;
+    }
+
+    foreach ( $entries as $entry ) {
+        if ( '.' === $entry || '..' === $entry ) {
+            continue;
+        }
+
+        $entry_path = $path . DIRECTORY_SEPARATOR . $entry;
+
+        if ( is_dir( $entry_path ) ) {
+            pie_custom_functions_delete_directory_recursive( $entry_path );
+        } else {
+            unlink( $entry_path );
+        }
+    }
+
+    return rmdir( $path );
 }
 
 /**

--- a/pie-custom-functions.php
+++ b/pie-custom-functions.php
@@ -4,7 +4,7 @@
  * Description: Required Functionality for PIE Hosting
  * Author: The team at PIE
  * Author URI: https://pie.co.de
- * Version: 1.5.1
+ * Version: 1.5.0
  * Requires PHP: 8.0
  * License: GPL2
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html

--- a/pie-custom-functions.php
+++ b/pie-custom-functions.php
@@ -63,42 +63,25 @@ function pie_custom_functions_init(): void {
         require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
     }
 
-    update_option( 'pie_custom_functions_version', get_plugin_data( __FILE__ )['Version'] );
-
-    $local_mu_plugin_file = plugin_dir_path( __FILE__ ) . 'pie-custom-functions-mu.php';
+    $local_mu_plugin_file      = plugin_dir_path( __FILE__ ) . 'pie-custom-functions-mu.php';
     $local_mu_plugin_directory = plugin_dir_path( __FILE__ ) . 'pie';
 
-    // Ensure MU plugin directory is available
+    // Ensure MU plugin directory is available.
     if ( ! defined( 'WPMU_PLUGIN_DIR' ) ) {
         error_log( '[PIE Custom Functions] WPMU_PLUGIN_DIR not defined - MU plugins not supported' );
-        wp_die( 
+        wp_die(
             __( 'PIE Hosting Companion activation failed: MU plugins directory not available. Please contact your hosting provider.', 'pie-custom-functions' ),
             __( 'Plugin Activation Error', 'pie-custom-functions' ),
             array( 'back_link' => true )
         );
     }
 
-    // Set the paths for the MU plugin file and pie directory
-    $destination_mu_plugin_file = WPMU_PLUGIN_DIR . '/pie-custom-functions-mu.php';
+    $destination_mu_plugin_file      = WPMU_PLUGIN_DIR . '/pie-custom-functions-mu.php';
     $destination_mu_plugin_directory = WPMU_PLUGIN_DIR . '/pie';
 
-    // Copy the MU plugin file (overwrites existing)
-    if ( ! copy( $local_mu_plugin_file, $destination_mu_plugin_file ) ) {
-        error_log( '[PIE Custom Functions] Failed to copy MU plugin file to: ' . $destination_mu_plugin_file );
-        wp_die( 
-            __( 'PIE Hosting Companion activation failed: Could not copy MU plugin file. Please check file permissions.', 'pie-custom-functions' ),
-            __( 'Plugin Activation Error', 'pie-custom-functions' ),
-            array( 'back_link' => true )
-        );
-    }
-    
-    // Copy the pie directory using native PHP (no WP_Filesystem dependency).
+    // Copy the pie/ directory first — the MU loader depends on files inside it.
+    // If this fails the MU loader file is not touched, so the site stays on the previous version.
     if ( ! copy_directory_recursive( $local_mu_plugin_directory, $destination_mu_plugin_directory ) ) {
-        // Clean up the MU plugin file if directory copy failed.
-        if ( file_exists( $destination_mu_plugin_file ) ) {
-            unlink( $destination_mu_plugin_file );
-        }
-
         error_log( '[PIE Custom Functions] Failed to copy pie directory to: ' . $destination_mu_plugin_directory );
         wp_die(
             __( 'PIE Hosting Companion activation failed: Could not copy pie directory. Please check file permissions.', 'pie-custom-functions' ),
@@ -106,6 +89,20 @@ function pie_custom_functions_init(): void {
             array( 'back_link' => true )
         );
     }
+
+    // Copy the MU loader file after its dependencies are in place.
+    // If this fails the version option is not bumped, so the next request retries the full update.
+    if ( ! copy( $local_mu_plugin_file, $destination_mu_plugin_file ) ) {
+        error_log( '[PIE Custom Functions] Failed to copy MU plugin file to: ' . $destination_mu_plugin_file );
+        wp_die(
+            __( 'PIE Hosting Companion activation failed: Could not copy MU plugin file. Please check file permissions.', 'pie-custom-functions' ),
+            __( 'Plugin Activation Error', 'pie-custom-functions' ),
+            array( 'back_link' => true )
+        );
+    }
+
+    // Both copies succeeded — safe to record the new version.
+    update_option( 'pie_custom_functions_version', get_plugin_data( __FILE__ )['Version'] );
 }
 
 /**

--- a/pie-custom-functions.php
+++ b/pie-custom-functions.php
@@ -4,7 +4,7 @@
  * Description: Required Functionality for PIE Hosting
  * Author: The team at PIE
  * Author URI: https://pie.co.de
- * Version: 1.5.0
+ * Version: 1.5.1
  * Requires PHP: 8.0
  * License: GPL2
  * License URI: https://www.gnu.org/licenses/gpl-2.0.html
@@ -23,7 +23,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Hookups
-register_activation_hook( __FILE__ , __NAMESPACE__ . '\pie_custom_functions_init' );
+register_activation_hook( __FILE__, function() {
+    pie_custom_functions_init( true );
+} );
 add_action( 'plugins_loaded', __NAMESPACE__ . '\pie_custom_functions_load_composer' );
 add_action( 'plugins_loaded', __NAMESPACE__ . '\update_check' );
 add_filter( 'all_plugins', __NAMESPACE__ . '\hide_pie_custom_functions_mu_plugin_from_plugins_list' );
@@ -55,12 +57,15 @@ function pie_custom_functions_load_composer(): void {
  * temp-and-rename strategy so the live directory is never partially updated.
  * The MU loader is copied only after the directory swap succeeds. If either
  * step fails the version option is not bumped, allowing the next request to
- * retry the full update.
+ * retry the full update. On the activation path failures call wp_die() to show
+ * an error screen; on the auto-update path they log silently and return so
+ * requests continue normally.
  *
  * @since 1.0.0
+ * @param bool $is_activation True when called from the activation hook, false on auto-update.
  * @return void
  */
-function pie_custom_functions_init(): void {
+function pie_custom_functions_init( bool $is_activation = false ): void {
 
     if ( ! function_exists( 'get_plugin_data' ) ) {
         require_once( ABSPATH . 'wp-admin/includes/plugin.php' );
@@ -72,11 +77,14 @@ function pie_custom_functions_init(): void {
     // Ensure MU plugin directory is available.
     if ( ! defined( 'WPMU_PLUGIN_DIR' ) ) {
         error_log( '[PIE Custom Functions] WPMU_PLUGIN_DIR not defined - MU plugins not supported' );
-        wp_die(
-            __( 'PIE Hosting Companion activation failed: MU plugins directory not available. Please contact your hosting provider.', 'pie-custom-functions' ),
-            __( 'Plugin Activation Error', 'pie-custom-functions' ),
-            array( 'back_link' => true )
-        );
+        if ( $is_activation ) {
+            wp_die(
+                __( 'PIE Hosting Companion activation failed: MU plugins directory not available. Please contact your hosting provider.', 'pie-custom-functions' ),
+                __( 'Plugin Activation Error', 'pie-custom-functions' ),
+                array( 'back_link' => true )
+            );
+        }
+        return;
     }
 
     $destination_mu_plugin_file      = WPMU_PLUGIN_DIR . '/pie-custom-functions-mu.php';
@@ -86,11 +94,14 @@ function pie_custom_functions_init(): void {
     // directory is never in a partial state. The MU loader is not touched if this fails.
     if ( ! pie_custom_functions_copy_directory_atomic( $local_mu_plugin_directory, $destination_mu_plugin_directory ) ) {
         error_log( '[PIE Custom Functions] Failed to copy pie directory to: ' . $destination_mu_plugin_directory );
-        wp_die(
-            __( 'PIE Hosting Companion activation failed: Could not copy pie directory. Please check file permissions.', 'pie-custom-functions' ),
-            __( 'Plugin Activation Error', 'pie-custom-functions' ),
-            array( 'back_link' => true )
-        );
+        if ( $is_activation ) {
+            wp_die(
+                __( 'PIE Hosting Companion activation failed: Could not copy pie directory. Please check file permissions.', 'pie-custom-functions' ),
+                __( 'Plugin Activation Error', 'pie-custom-functions' ),
+                array( 'back_link' => true )
+            );
+        }
+        return;
     }
 
     // Write the MU loader to a temp file in the same directory, then rename atomically
@@ -100,21 +111,27 @@ function pie_custom_functions_init(): void {
 
     if ( ! copy( $local_mu_plugin_file, $temp_mu_plugin_file ) ) {
         error_log( '[PIE Custom Functions] Failed to copy MU plugin file to: ' . $temp_mu_plugin_file );
-        wp_die(
-            __( 'PIE Hosting Companion activation failed: Could not copy MU plugin file. Please check file permissions.', 'pie-custom-functions' ),
-            __( 'Plugin Activation Error', 'pie-custom-functions' ),
-            array( 'back_link' => true )
-        );
+        if ( $is_activation ) {
+            wp_die(
+                __( 'PIE Hosting Companion activation failed: Could not copy MU plugin file. Please check file permissions.', 'pie-custom-functions' ),
+                __( 'Plugin Activation Error', 'pie-custom-functions' ),
+                array( 'back_link' => true )
+            );
+        }
+        return;
     }
 
     if ( ! rename( $temp_mu_plugin_file, $destination_mu_plugin_file ) ) {
         unlink( $temp_mu_plugin_file );
         error_log( '[PIE Custom Functions] Failed to promote MU plugin file to: ' . $destination_mu_plugin_file );
-        wp_die(
-            __( 'PIE Hosting Companion activation failed: Could not install MU plugin file. Please check file permissions.', 'pie-custom-functions' ),
-            __( 'Plugin Activation Error', 'pie-custom-functions' ),
-            array( 'back_link' => true )
-        );
+        if ( $is_activation ) {
+            wp_die(
+                __( 'PIE Hosting Companion activation failed: Could not install MU plugin file. Please check file permissions.', 'pie-custom-functions' ),
+                __( 'Plugin Activation Error', 'pie-custom-functions' ),
+                array( 'back_link' => true )
+            );
+        }
+        return;
     }
 
     // pie/ swap and MU loader promotion both succeeded — safe to record the new version.
@@ -181,9 +198,14 @@ function pie_custom_functions_copy_directory_atomic( string $source, string $des
     $temp = $destination . '-new';
     $old  = $destination . '-old';
 
-    // Remove any leftover temp directory from a previous failed attempt.
-    if ( is_dir( $temp ) ) {
-        pie_custom_functions_delete_directory_recursive( $temp );
+    // Clean up any leftover temp directories from previous failed attempts.
+    // If either cannot be fully removed the rename steps that follow would fail anyway.
+    if ( is_dir( $temp ) && ! pie_custom_functions_delete_directory_recursive( $temp ) ) {
+        return false;
+    }
+
+    if ( is_dir( $old ) && ! pie_custom_functions_delete_directory_recursive( $old ) ) {
+        return false;
     }
 
     // Copy into the temporary location — live directory is untouched until success.
@@ -199,9 +221,9 @@ function pie_custom_functions_copy_directory_atomic( string $source, string $des
     }
 
     if ( ! rename( $temp, $destination ) ) {
-        // Promotion failed — restore the previous directory.
-        if ( is_dir( $old ) ) {
-            rename( $old, $destination );
+        // Promotion failed — attempt to restore the previous directory.
+        if ( is_dir( $old ) && ! rename( $old, $destination ) ) {
+            error_log( '[PIE Custom Functions] CRITICAL: promotion and rollback both failed. The live pie/ directory may be missing at: ' . $destination );
         }
         pie_custom_functions_delete_directory_recursive( $temp );
         return false;
@@ -220,7 +242,7 @@ function pie_custom_functions_copy_directory_atomic( string $source, string $des
  *
  * @since 1.5.1
  * @param string $path Absolute path to the directory to delete.
- * @return bool True on success, false if the path is not a directory or cannot be scanned.
+ * @return bool True on success, false if the path is not a directory, cannot be scanned, or any file or subdirectory cannot be deleted.
  */
 function pie_custom_functions_delete_directory_recursive( string $path ): bool {
     if ( ! is_dir( $path ) ) {
@@ -240,9 +262,11 @@ function pie_custom_functions_delete_directory_recursive( string $path ): bool {
         $entry_path = $path . DIRECTORY_SEPARATOR . $entry;
 
         if ( is_dir( $entry_path ) ) {
-            pie_custom_functions_delete_directory_recursive( $entry_path );
-        } else {
-            unlink( $entry_path );
+            if ( ! pie_custom_functions_delete_directory_recursive( $entry_path ) ) {
+                return false;
+            }
+        } elseif ( ! unlink( $entry_path ) ) {
+            return false;
         }
     }
 


### PR DESCRIPTION
This PR updates the plugin activation/update initialization logic for the PIE Hosting Companion so the MU plugin’s dependent pie/ directory is copied before the MU loader file, and records the plugin version only after both copy operations succeed.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1215712806607352